### PR TITLE
Deploy docs to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - deploy-docs-gh-pages
 
       # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -35,7 +36,7 @@ jobs:
 
       - name:  🚀 Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,3 +32,10 @@ jobs:
         with:
           name: mkdocs
           path: site
+
+      - name:  🚀 Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - deploy-docs-gh-pages
 
       # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -36,7 +35,7 @@ jobs:
 
       - name:  🚀 Deploy
         uses: peaceiris/actions-gh-pages@v3
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site


### PR DESCRIPTION
This PR auto-deploys the docs to gh-pages.

You can see an example deployment here: https://techygrrrl.github.io/tau/

In order for this to work, you need to do an initial run of the workflow since the current workflow only runs on deployment to main. See this commit for details on how to enable for your branch: https://github.com/techygrrrl/tau/commit/2277812c8cae343ebecb02f7469723eddfe58ffd

After the initial run, you can proceed.

To set up:

1. Go into the repository settings 
2. Go to Pages
3. Set the `gh-pages` branch as the page for Github Pages to use
4. Choose `/root`

Here's a screenshot.

<img width="1156" alt="image" src="https://user-images.githubusercontent.com/88961088/173207342-f4d22456-0c5f-4df7-b943-9e1383ffc720.png">
